### PR TITLE
fix(sitemap): include about-us static page

### DIFF
--- a/app/sitemap/main.xml/route.ts
+++ b/app/sitemap/main.xml/route.ts
@@ -10,6 +10,7 @@ function generateStaticUrls(baseUrl: string): string {
     { path: '/collaboratives', priority: '0.8', changefreq: 'weekly' },
     { path: '/publishers', priority: '0.7', changefreq: 'weekly' },
     { path: '/sectors', priority: '0.7', changefreq: 'weekly' },
+    { path: '/about-us', priority: '0.5', changefreq: 'monthly' },
   ];
 
   return staticPages


### PR DESCRIPTION
## Summary
- `/about-us` already has full SEO metadata (`generatePageMetadata`) and JSON-LD structured data, but was never included in the sitemap's static pages list.
- Adds it alongside the other static pages (datasets, usecases, collaboratives, publishers, sectors).

## Test plan
- [x] Verified locally: `/sitemap/main.xml` now includes `<loc>.../about-us</loc>` with priority 0.5, changefreq monthly