### PR TITLE
 Fix Keycloak logout confirmation and stale logged-in avatar after token refresh fails

### DIFF
--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -5,20 +5,24 @@ import { authOptions } from '../[...nextauth]/options';
 
 export async function GET() {
   const session = await getServerSession(authOptions);
+  const idToken = session?.id_token;
 
-  if (session) {
-    
-    const idToken = session.id_token;
-
-    const logoutUrl = `${env.AUTH_ISSUER}/protocol/openid-connect/logout?id_token_hint=${idToken}&post_logout_redirect_uri=${encodeURIComponent(env.NEXTAUTH_URL)}`;
+  if (session && idToken && session.error !== 'RefreshAccessTokenError') {
+    const logoutUrl = `${env.AUTH_ISSUER}/protocol/openid-connect/logout?${new URLSearchParams(
+      {
+        id_token_hint: idToken,
+        post_logout_redirect_uri: env.NEXTAUTH_URL,
+        client_id: env.KEYCLOAK_CLIENT_ID,
+      }
+    ).toString()}`;
 
     return new Response(JSON.stringify({ url: logoutUrl }), {
       status: 200,
       headers: { 'Content-Type': 'application/json' },
     });
   }
-  
-  return new Response(JSON.stringify({ url: env.NEXTAUTH_URL }), {
+
+  return new Response(JSON.stringify({ url: `${env.NEXTAUTH_URL}/login` }), {
     status: 200,
     headers: { 'Content-Type': 'application/json' },
   });

--- a/components/SessionGuard.tsx
+++ b/components/SessionGuard.tsx
@@ -2,20 +2,24 @@
 
 import { ReactNode, useEffect } from 'react';
 import { usePathname } from 'next/navigation';
-import { signIn, useSession } from 'next-auth/react';
+import { signIn, signOut, useSession } from 'next-auth/react';
 
 export default function SessionGuard({ children }: { children: ReactNode }) {
   const { data } = useSession();
-
   const pathname = usePathname();
 
   useEffect(() => {
-    if (
-      data?.error === 'RefreshAccessTokenError' &&
-      pathname.includes('dashboard')
-    ) {
-      signIn('keycloak');
-    }
+    if (data?.error !== 'RefreshAccessTokenError') return;
+
+    const clearExpiredSession = async () => {
+      await signOut({ redirect: false });
+
+      if (pathname.includes('dashboard')) {
+        signIn('keycloak');
+      }
+    };
+
+    void clearExpiredSession();
   }, [data, pathname]);
 
   return <>{children}</>;


### PR DESCRIPTION
Summary 
1. Hitting Log Out with no usable session was sending users to Keycloak /logout without a valid id_token_hint, which showed the “Do you want to log out?” page. Logout now goes to Keycloak only when a session, id_token, and successful refresh exist; otherwise it goes to /login, which already calls signIn('keycloak').So it was suggested don't show logout page instead redirect to login 
Issue : This logout page does not make sense as we are not giving any option other than logging out 

<img width="1577" height="569" alt="image" src="https://github.com/user-attachments/assets/a9918e16-27a6-4918-b5db-f6d4bfa3a52d" />

On Logout:
Still logged in: tell Keycloak to log out in the background, then go to login. Do not show the logout page.
Already expired: skip Keycloak. Go straight to login.
Users should never see the Keycloak logout page.

2.After RefreshAccessTokenError, NextAuth still kept session.user, so the homepage avatar sometimes looked logged in. SessionGuard now signOuts to clear that dead session. Dashboard still redirects to Keycloak login, same as before.